### PR TITLE
tmp permissions

### DIFF
--- a/lib/capistrano/cakephp/defaults.rb
+++ b/lib/capistrano/cakephp/defaults.rb
@@ -4,6 +4,7 @@ set_if_empty :cakephp_user, :local_user
 
 set_if_empty :linked_dirs, [
   'logs',
+  'tmp'
   'tmp/cache/models',
   'tmp/cache/persistent',
   'tmp/cache/views',


### PR DESCRIPTION
`tmp` should be writeable otherwise you get problems if you deploy a development envorinment with enabled DebugKit. DebugKit isn't able to save the sqlite file without the correct permissions.